### PR TITLE
Improve docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: opentripplanner
-Title: Open Trip Planner for R
+Title: OpenTripPlanner for R
 Version: 0.0.1.0000
 Authors@R: c(
     person("Marcus", "Young",   email = "M.A.Young@soton.ac.uk", role = c("aut", "cre"),
@@ -12,9 +12,9 @@ Authors@R: c(
       comment = c(ORCID = "0000-0003-1912-4890"))
     )
 Maintainer: Malcolm Morgan <m.morgan1@leeds.ac.uk>
-Description: An R interface for Open Trip Planner <http://www.opentripplanner.org/>.
+Description: An R interface for OpenTripPlanner <http://www.opentripplanner.org/>.
     OpenTripPlanner (OTP) is an open source platform for multi-modal and multi-agency
-    journey planning written in Java. OTP provides a REST API which Open Trip Planner
+    journey planning written in Java. OTP provides a REST API which OpenTripPlanner
     for R uses to connect to OTP.
 License: GPL-3
 URL: https://github.com/ITSLeeds/opentripplanner, https://itsleeds.github.io/opentripplanner/

--- a/R/opentripplanner-package.R
+++ b/R/opentripplanner-package.R
@@ -1,7 +1,7 @@
-#' Open Trip Planner of R
+#' OpenTripPlanner of R
 #'
 #' @description
-#' The goal of Open Trip Planner for R is to provide a simple R interface to Open Trip Planner (OTP).
+#' The goal of OpenTripPlanner for R is to provide a simple R interface to OpenTripPlanner (OTP).
 #' The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java
 #' and R to use this package.
 #' @keywords routing transport mulitmodal opentripplanner

--- a/R/otp-plan.R
+++ b/R/otp-plan.R
@@ -368,7 +368,7 @@ otp_plan_internal <- function(otpcon = NA,
 }
 
 
-#' Convert output from Open Trip Planner into sf object
+#' Convert output from OpenTripPlanner into sf object
 #'
 #' @param obj Object from the OTP API to process
 #' @param full_elevation logical should the full elevation profile be returned (if available)

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -42,8 +42,7 @@ otp_build_graph <- function(otp = NULL,
                             dir = NULL,
                             memory = 2,
                             router = "default",
-                            analyst = FALSE,
-                            compiled = FALSE) {
+                            analyst = FALSE) {
 
   # Run Checks
   otp_checks(otp = otp, dir = dir, router = router, graph = FALSE)

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -246,7 +246,7 @@ otp_checks <- function(otp = NULL, dir = NULL, router = NULL, graph = FALSE) {
 
   # TODO: test on Linux
   # Check we have correct verrsion of Java
-  java_version <- try(system("java -version", intern = TRUE))
+  try(java_version <- system2("java", "-version", stdout = TRUE, stderr = TRUE))
   if (class(java_version) == "try-error") {
     warning("R was unable to detect a version of Java")
     stop()

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -10,6 +10,7 @@
 #' @param memory A positive integer. Amount of memory to assign to the OTP in GB, default is 2
 #' @param router A character string for the name of the router, must match with contents of dir, default "default"
 #' @param analyst Logical, should analyst feature be built, default FALSE
+#' @param compiled Using a compiled system install of OTP? False by default.
 #' @return
 #' Returns and log messages produced by OTP, and will return the message "Graph built" if successful
 #' @details
@@ -42,28 +43,42 @@ otp_build_graph <- function(otp = NULL,
                             dir = NULL,
                             memory = 2,
                             router = "default",
-                            analyst = FALSE) {
+                            analyst = FALSE,
+                            compiled = FALSE) {
+
+  if(!grepl(pattern = "jar", x = otp)) {
+    compiled = TRUE
+  }
   # Run Checks
   otp_checks(otp = otp, dir = dir, router = router, graph = FALSE)
   message("Basic checks completed, building graph, this may take a few minutes")
 
   # Set up OTP
-  text <- paste0(
-    "java -Xmx",
-    memory,
-    'G -jar "',
-    otp,
-    '" --build "',
-    dir,
-    "/graphs/",
-    router,
-    '"'
-  )
+  if(compiled) {
+    text <- paste0(
+      otp,
+      " --build ",
+      dir,
+      "/graphs/",
+      router
+    )
+  } else {
+    text <- paste0(
+      "java -Xmx",
+      memory,
+      'G -jar "',
+      otp,
+      '" --build "',
+      dir,
+      "/graphs/",
+      router,
+      '"'
+    )
+  }
 
   if (analyst) {
     text <- paste0(text, " --analyst")
   }
-
 
   set_up <- try(system(text, intern = TRUE))
 
@@ -132,8 +147,7 @@ otp_setup <- function(otp = NULL,
 
   # Set up OTP
   if (checkmate::testOS("linux")) {
-    message("You're on linux, this function is not yet supported")
-    stop()
+    message("You're on linux, well done")
   } else if (checkmate::testOS("windows") | checkmate::testOS("mac")) {
     text <- paste0(
       "java -Xmx", memory, 'G -jar "',
@@ -240,7 +254,7 @@ otp_stop <- function() {
 
 otp_checks <- function(otp = NULL, dir = NULL, router = NULL, graph = FALSE) {
   # Checks
-  checkmate::assertFileExists(otp, extension = "jar")
+  # checkmate::assertFileExists(otp, extension = "jar")
   checkmate::assertDirectoryExists(dir)
   checkmate::assertDirectoryExists(paste0(dir, "/graphs/", router))
 

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -10,7 +10,6 @@
 #' @param memory A positive integer. Amount of memory to assign to the OTP in GB, default is 2
 #' @param router A character string for the name of the router, must match with contents of dir, default "default"
 #' @param analyst Logical, should analyst feature be built, default FALSE
-#' @param compiled Using a compiled system install of OTP? False by default.
 #' @return
 #' Returns and log messages produced by OTP, and will return the message "Graph built" if successful
 #' @details
@@ -46,35 +45,21 @@ otp_build_graph <- function(otp = NULL,
                             analyst = FALSE,
                             compiled = FALSE) {
 
-  if(!grepl(pattern = "jar", x = otp)) {
-    compiled = TRUE
-  }
   # Run Checks
   otp_checks(otp = otp, dir = dir, router = router, graph = FALSE)
   message("Basic checks completed, building graph, this may take a few minutes")
 
-  # Set up OTP
-  if(compiled) {
-    text <- paste0(
-      otp,
-      " --build ",
-      dir,
-      "/graphs/",
-      router
-    )
-  } else {
-    text <- paste0(
-      "java -Xmx",
-      memory,
-      'G -jar "',
-      otp,
-      '" --build "',
-      dir,
-      "/graphs/",
-      router,
-      '"'
-    )
-  }
+  text <- paste0(
+    "java -Xmx",
+    memory,
+    'G -jar "',
+    otp,
+    '" --build "',
+    dir,
+    "/graphs/",
+    router,
+    '"'
+  )
 
   if (analyst) {
     text <- paste0(text, " --analyst")

--- a/README.Rmd
+++ b/README.Rmd
@@ -15,9 +15,9 @@ knitr::opts_chunk$set(
 )
 ```
 
-# Open Trip Planner for R
+# OpenTripPlanner for R
 
-The goal of Open Trip Planner for R is to provide a simple R interface to [Open Trip Planner (OTP)](https://www.opentripplanner.org/). The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java and R to use this package.
+The goal of OpenTripPlanner for R is to provide a simple R interface to [OpenTripPlanner (OTP)](https://www.opentripplanner.org/). The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java and R to use this package.
 
 This package can be used to interface with a remote instance of OTP (e.g. a website) or help you set up and manage a local version of OTP for private use. For more information on what OTP is, see the [Prerequisites vignette](https://itsleeds.github.io/opentripplanner/articles/prerequisites.html).
 
@@ -25,9 +25,9 @@ Basic setup and routing functions are outlined in the [getting started vignette]
 
 ## Installation
 
-### Open Trip Planner
+### OpenTripPlanner
 
-To use Open Trip Planner on your local computer you will need to install Java 8 and download the latest version of OTP. Instructions on installing Java and setting up OTP can be found in the [getting started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
+To use OpenTripPlanner on your local computer you will need to install Java 8 and download the latest version of OTP. Instructions on installing Java and setting up OTP can be found in the [getting started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
 
 ### R Package
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ output: github_document
 
 
 
-# Open Trip Planner for R
+# OpenTripPlanner for R
 
-The goal of Open Trip Planner for R is to provide a simple R interface to [Open Trip Planner (OTP)](https://www.opentripplanner.org/). The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java and R to use this package.
+The goal of OpenTripPlanner for R is to provide a simple R interface to [OpenTripPlanner (OTP)](https://www.opentripplanner.org/). The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java and R to use this package.
 
 This package can be used to interface with a remote instance of OTP (e.g. a website) or help you set up and manage a local version of OTP for private use. For more information on what OTP is, see the [Prerequisites vignette](https://itsleeds.github.io/opentripplanner/articles/prerequisites.html).
 
@@ -18,9 +18,9 @@ Basic setup and routing functions are outlined in the [getting started vignette]
 
 ## Installation
 
-### Open Trip Planner
+### OpenTripPlanner
 
-To use Open Trip Planner on your local computer you will need to install Java 8 and download the latest version of OTP. Instructions on installing Java and setting up OTP can be found in the [getting started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
+To use OpenTripPlanner on your local computer you will need to install Java 8 and download the latest version of OTP. Instructions on installing Java and setting up OTP can be found in the [getting started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
 
 ### R Package
 

--- a/man/opentripplanner-package.Rd
+++ b/man/opentripplanner-package.Rd
@@ -4,9 +4,9 @@
 \name{opentripplanner-package}
 \alias{opentripplanner}
 \alias{opentripplanner-package}
-\title{Open Trip Planner of R}
+\title{OpenTripPlanner of R}
 \description{
-The goal of Open Trip Planner for R is to provide a simple R interface to Open Trip Planner (OTP).
+The goal of OpenTripPlanner for R is to provide a simple R interface to OpenTripPlanner (OTP).
 The OTP is a multimodal trip planning service. OTP is written in Java, and you will need both Java
 and R to use this package.
 }

--- a/man/otp_build_graph.Rd
+++ b/man/otp_build_graph.Rd
@@ -5,7 +5,7 @@
 \title{Build an OTP Graph}
 \usage{
 otp_build_graph(otp = NULL, dir = NULL, memory = 2,
-  router = "default", analyst = FALSE, compiled = FALSE)
+  router = "default", analyst = FALSE)
 }
 \arguments{
 \item{otp}{A character string, path to the OTP .jar file}

--- a/man/otp_build_graph.Rd
+++ b/man/otp_build_graph.Rd
@@ -5,7 +5,7 @@
 \title{Build an OTP Graph}
 \usage{
 otp_build_graph(otp = NULL, dir = NULL, memory = 2,
-  router = "default", analyst = FALSE)
+  router = "default", analyst = FALSE, compiled = FALSE)
 }
 \arguments{
 \item{otp}{A character string, path to the OTP .jar file}
@@ -17,6 +17,8 @@ otp_build_graph(otp = NULL, dir = NULL, memory = 2,
 \item{router}{A character string for the name of the router, must match with contents of dir, default "default"}
 
 \item{analyst}{Logical, should analyst feature be built, default FALSE}
+
+\item{compiles}{Using a compiled system install of OTP? False by default.}
 }
 \value{
 Returns and log messages produced by OTP, and will return the message "Graph built" if successful

--- a/man/otp_build_graph.Rd
+++ b/man/otp_build_graph.Rd
@@ -18,7 +18,7 @@ otp_build_graph(otp = NULL, dir = NULL, memory = 2,
 
 \item{analyst}{Logical, should analyst feature be built, default FALSE}
 
-\item{compiles}{Using a compiled system install of OTP? False by default.}
+\item{compiled}{Using a compiled system install of OTP? False by default.}
 }
 \value{
 Returns and log messages produced by OTP, and will return the message "Graph built" if successful

--- a/man/otp_build_graph.Rd
+++ b/man/otp_build_graph.Rd
@@ -17,8 +17,6 @@ otp_build_graph(otp = NULL, dir = NULL, memory = 2,
 \item{router}{A character string for the name of the router, must match with contents of dir, default "default"}
 
 \item{analyst}{Logical, should analyst feature be built, default FALSE}
-
-\item{compiled}{Using a compiled system install of OTP? False by default.}
 }
 \value{
 Returns and log messages produced by OTP, and will return the message "Graph built" if successful

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'opentripplanner: R interface to the Open Trip Planner'
+title: 'opentripplanner: R interface to the OpenTripPlanner'
 authors:
 - affiliation: 1
   name: Malcolm Morgan

--- a/vignettes/advanced_features.Rmd
+++ b/vignettes/advanced_features.Rmd
@@ -130,7 +130,7 @@ For troubleshooting routing issues, you can visualise the traversal permissions 
 
 You can read more about the different debug layers in the official OTP documentation: [http://docs.opentripplanner.org/en/latest/Troubleshooting-Routing/#debug-layers](http://docs.opentripplanner.org/en/latest/Troubleshooting-Routing/#debug-layers).
 
-## Configuring Open Trip Planner
+## Configuring OpenTripPlanner
 
 How OTP works can be configures using json files. `build-config.json` is used during graph building (i.e. `otp_build_graph()`). While `router-config.json` is used during setup (i.e. `otp_setup()`). These files must be saved with the rest of your data and each router can have a unique configuration.
 
@@ -149,7 +149,7 @@ otp_write_config(router_config,                # Save the config file
 
 ```
 
-There is much more information about configuring Open Trip Planner at https://opentripplanner.readthedocs.io/en/latest/Configuration/ 
+There is much more information about configuring OpenTripPlanner at https://opentripplanner.readthedocs.io/en/latest/Configuration/ 
 
 
 

--- a/vignettes/opentripplanner.Rmd
+++ b/vignettes/opentripplanner.Rmd
@@ -62,6 +62,7 @@ download.file("https://github.com/ITSLeeds/opentripplanner/releases/download/0.1
 unzip("isle-of-wight-demo.zip", exdir = "graphs/default")
 unlink("isle-of-wight-demo.zip")
 ```
+
 Now we can build the graph. This code will create a new file `Graph.obj` that will be saved in the location defined by `path_data`. 
 
 ```{r eval=FALSE}

--- a/vignettes/opentripplanner.Rmd
+++ b/vignettes/opentripplanner.Rmd
@@ -18,7 +18,7 @@ A major advantage of running your own multi-modal route planner is the ability t
 
 ## Prerequisites
 
-You will need to have installed R, RStudio, and Java 8. For more details on the software required see the [prerequisites vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html) included with this package.
+You will need to have installed R, RStudio, and Java 8. For more details on the software required see the [prerequisites vignette](https://itsleeds.github.io/opentripplanner/articles/prerequisites.html) included with this package.
 
 ## Installation
 

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -12,8 +12,8 @@ vignette: >
 
 ## Introduction
 
-This vignette provides guidance for people who new to OpenTripPlanner (OTP).  It assumes some prior-knowledge of R (see An Introduction to R [online](https://cran.r-project.org/doc/manuals/r-release/R-intro.pdf) or from within R by running `help.start()`, or introductory tutorials such as DataCamp's [free](https://www.datacamp.com/courses/free-introduction-to-r) Introduction to R course.
-After you have R and OTP installed, and have become familiar with them, we recommend working through [Getting Started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
+This vignette provides guidance for people who new to OpenTripPlanner (OTP) and R.
+After you have R and OTP installed, and have become familiar with them (e.g. by reading this vignettee), we recommend working through [Getting Started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
 
 ## What is this package for, and what is a package anyway?
 
@@ -23,9 +23,9 @@ For more on local versus remote routing services, see the Transportation chapter
 
 ### What is OpenTripPlanner?
 
-OpenTripPlanner (OTP) is a free, open-source, and cross-platform multi-modal route planner written in JAVA.  It is like having your own private version of Google Maps.
+OTP is a free, open-source, and cross-platform multi-modal route planner written in JAVA.  It is like having your own private version of Google Maps.
 
-You can find a lot more information about OTP at:
+Learn more about OTP at:
 
 * http://www.opentripplanner.org/
 * https://wiki.openstreetmap.org/wiki/OpenTripPlanner
@@ -38,6 +38,8 @@ You can find a lot more information about R at:
 
 * https://www.r-project.org/ 
 * https://en.wikipedia.org/wiki/R_(programming_language) 
+
+To get started with R, see An Introduction to R [online](https://cran.r-project.org/doc/manuals/r-release/R-intro.pdf) or from within R by running `help.start()`, or introductory tutorials such as DataCamp's [free](https://www.datacamp.com/courses/free-introduction-to-r) Introduction to R course.
 
 ### What is an R package?
 
@@ -52,14 +54,6 @@ This package allows you to use the trip planning power of OTP with the analytica
 ## What do I need to get started?
 
 You will need to install some software to use OTP and R.
-
-### To use OTP
-
-* Download free Java 8 from https://www.java.com/en/download/ and install Java. You will need the correct version for your operating system. If possible the 64 Bit version of Java is preferable, especially if you want to use OTP over large areas.
-
-**Note** OTP does not work with later version of Java such as Java 11.
-
-To install Java 8 on Linux, we recommend instructions at [medium.com/coderscorner](https://medium.com/coderscorner/installing-oracle-java-8-in-ubuntu-16-10-845507b13343).
 
 ### To Use R
 
@@ -78,6 +72,41 @@ If you have never used R before there a lots of free tutorials to get you starte
 * http://www.r-tutor.com/r-introduction
 
 
+### To use OTP
+
+* Download free Java 8 from https://www.java.com/en/download/ and install Java. You will need the correct version for your operating system. If possible the 64 Bit version of Java is preferable, especially if you want to use OTP over large areas.
+
+**Note** OTP does not work with later version of Java such as Java 11.
+
+To install Java 8 on Linux, we recommend instructions at [medium.com/coderscorner](https://medium.com/coderscorner/installing-oracle-java-8-in-ubuntu-16-10-845507b13343) and on [StackOverflow](https://askubuntu.com/questions/740757/switch-between-multiple-java-versions).
+
+As outlined  8 can be installed with the following commands on Ubuntu:
+
+```{r, engine='bash'}
+sudo apt-add-repository ppa:webupd8team/java
+sudo apt-get update
+sudo apt-get install oracle-java8-installer
+```
+
+
+
+
+
+You can also compile the latest version of OTP from source with the following commands:
+
+```{r, engine='bash'}
+sudo apt-get install openjdk-8-jdk maven git
+mkdir git
+cd git
+git clone git@github.com:opentripplanner/OpenTripPlanner.git
+cd OpenTripPlanner
+mvn clean package
+```
+
+
+## Check the installation
+
+To check if the 
 
 ## Next Steps
 

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -82,7 +82,7 @@ To install Java 8 on Linux, we recommend instructions at [medium.com/coderscorne
 
 As outlined  8 can be installed with the following commands on Ubuntu:
 
-```{r, engine='bash'}
+```{r, engine='bash', eval=FALSE}
 sudo apt-add-repository ppa:webupd8team/java
 sudo apt-get update
 sudo apt-get install oracle-java8-installer

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -12,11 +12,14 @@ vignette: >
 
 ## Introduction
 
-This vignette is to provide guidance for people who are completely unfamiliar with Open Trip Planner and/or R.  It assumes no prior-knowledge.  If you are familiar with R and/or OTP then you may find the [Getting Started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html) more useful.
+This vignette provides guidance for people who new to Open Trip Planner (OTP).  It assumes some prior-knowledge of R (see An Introduction to R [online](https://cran.r-project.org/doc/manuals/r-release/R-intro.pdf) or from within R by running `help.start()`, or introductory tutorials such as DataCamp's [free](https://www.datacamp.com/courses/free-introduction-to-r) Introduction to R course.
+After you have R and OTP installed, and have become familiar with them, we recommend working through [Getting Started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
 
 ## What is this package for, and what is a package anyway?
 
-The Open Trip Planner for R package makes it easier for R and Open Trip Planner to communicate.
+The `opentripplanner` R package makes it easier for R and Open Trip Planner to communicate.
+Specifically, it allows you to do use R to control OTP and use it as a local routing service.
+For more on local versus remote routing services, see the Transportation chapter in [Geocomputation with R](https://geocompr.robinlovelace.net/transport.html).
 
 ### What is Open Trip Planner?
 

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -88,25 +88,54 @@ sudo apt-get update
 sudo apt-get install oracle-java8-installer
 ```
 
-
-
-
-
 You can also compile the latest version of OTP from source with the following commands:
 
-```{r, engine='bash'}
+```{r, engine='bash', eval=FALSE}
 sudo apt-get install openjdk-8-jdk maven git
 mkdir git
 cd git
 git clone git@github.com:opentripplanner/OpenTripPlanner.git
 cd OpenTripPlanner
 mvn clean package
+chmod +x otp
+# sudo cp -Rv target otp /usr/bin/
+```
+
+The penultimate line ensures the `otp` script, which calls OpenTripPlanner, is executable.
+The final line makes `otp` available to the system path: it should work from any directory.
+Check the process has worked by executing the following command, which should generate of the type shown below:
+
+```
+./otp --help
+OpenTripPlanner 1.4.0-SNAPSHOT 135671945eeab2a8fd1cd285fbda8349540cdc34
+Usage: java -Xmx[several]G -jar otp.jar [options] Files for graph build.
+  Options:
+        --analyst
+       Enable OTP Analyst extensions.
+       Default: false
 ```
 
 
 ## Check the installation
 
-To check if the 
+To check if the installation has worked, run the following lines of code:
+
+```{r, eval=FALSE}
+library(opentripplanner)
+path_otp <- "otp" # for system install
+# path_otp <- "~/programs/otp.jar" # for local java file
+path_data <- getwd()
+dir.create("graphs")
+dir.create("graphs/default")
+download.file("https://github.com/ITSLeeds/opentripplanner/releases/download/0.1/isle-of-wight-demo.zip", 
+              destfile = "isle-of-wight-demo.zip", mode="wb")
+unzip("isle-of-wight-demo.zip", exdir = "graphs/default")
+unlink("isle-of-wight-demo.zip")
+log <- otp_build_graph(otp = path_otp, dir = path_data) 
+otp_setup(otp = path_otp, dir = path_data)
+otp_stop()
+```
+
 
 ## Next Steps
 

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -12,16 +12,16 @@ vignette: >
 
 ## Introduction
 
-This vignette provides guidance for people who new to Open Trip Planner (OTP).  It assumes some prior-knowledge of R (see An Introduction to R [online](https://cran.r-project.org/doc/manuals/r-release/R-intro.pdf) or from within R by running `help.start()`, or introductory tutorials such as DataCamp's [free](https://www.datacamp.com/courses/free-introduction-to-r) Introduction to R course.
+This vignette provides guidance for people who new to OpenTripPlanner (OTP).  It assumes some prior-knowledge of R (see An Introduction to R [online](https://cran.r-project.org/doc/manuals/r-release/R-intro.pdf) or from within R by running `help.start()`, or introductory tutorials such as DataCamp's [free](https://www.datacamp.com/courses/free-introduction-to-r) Introduction to R course.
 After you have R and OTP installed, and have become familiar with them, we recommend working through [Getting Started vignette](https://itsleeds.github.io/opentripplanner/articles/opentripplanner.html).
 
 ## What is this package for, and what is a package anyway?
 
-The `opentripplanner` R package makes it easier for R and Open Trip Planner to communicate.
+The `opentripplanner` R package makes it easier for R and OpenTripPlanner to communicate.
 Specifically, it allows you to do use R to control OTP and use it as a local routing service.
 For more on local versus remote routing services, see the Transportation chapter in [Geocomputation with R](https://geocompr.robinlovelace.net/transport.html).
 
-### What is Open Trip Planner?
+### What is OpenTripPlanner?
 
 OpenTripPlanner (OTP) is a free, open-source, and cross-platform multi-modal route planner written in JAVA.  It is like having your own private version of Google Maps.
 
@@ -43,7 +43,7 @@ You can find a lot more information about R at:
 
 An R package is a small piece of software that extends the basic capabilities of R. It is a bit like how a new phone can do some things out of the box (make phone calls, send email) but you have to install apps to add extra abilities.
 
-### Why would I want to use Open Trip Planner for R?
+### Why would I want to use OpenTripPlanner for R?
 
 OTP can be used to run public route finding services such as https://ride.trimet.org but it can also be run on your own private computer or server. If you want to analyse a transport network OTP is a very useful tool. However, OTP is, as the name suggests, a Trip Planner, not analytical software.  So, while OTP can find the fastest route from A to B or find all the places that are within a 20-minute walk of C, it cannot answer a question like “how many people live within 10-minutes of a park?”  This is where R can help.  R can process multiple spatial datasets such a population densities and park locations, but does not have a built-in journey planner. 
 

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -80,41 +80,7 @@ If you have never used R before there a lots of free tutorials to get you starte
 
 To install Java 8 on Linux, we recommend instructions at [medium.com/coderscorner](https://medium.com/coderscorner/installing-oracle-java-8-in-ubuntu-16-10-845507b13343) and on [StackOverflow](https://askubuntu.com/questions/740757/switch-between-multiple-java-versions).
 
-As outlined  8 can be installed with the following commands on Ubuntu:
-
-```{r, engine='bash', eval=FALSE}
-sudo apt-add-repository ppa:webupd8team/java
-sudo apt-get update
-sudo apt-get install oracle-java8-installer
-```
-
-You can also compile the latest version of OTP from source with the following commands:
-
-```{r, engine='bash', eval=FALSE}
-sudo apt-get install openjdk-8-jdk maven git
-mkdir git
-cd git
-git clone git@github.com:opentripplanner/OpenTripPlanner.git
-cd OpenTripPlanner
-mvn clean package
-chmod +x otp
-# sudo cp -Rv target otp /usr/bin/
-```
-
-The penultimate line ensures the `otp` script, which calls OpenTripPlanner, is executable.
-The final line makes `otp` available to the system path: it should work from any directory.
-Check the process has worked by executing the following command, which should generate of the type shown below:
-
-```
-./otp --help
-OpenTripPlanner 1.4.0-SNAPSHOT 135671945eeab2a8fd1cd285fbda8349540cdc34
-Usage: java -Xmx[several]G -jar otp.jar [options] Files for graph build.
-  Options:
-        --analyst
-       Enable OTP Analyst extensions.
-       Default: false
-```
-
+You can also compile the latest version of OTP from source, as outlined at [docs.opentripplanner.org/](http://docs.opentripplanner.org/en/latest/Getting-OTP/).
 
 ## Check the installation
 


### PR DESCRIPTION
These changes make a few general improvements to the documentation. The biggest change is that `otp_build_graph()` now works with a system-wide install of `otp` on Unix-like OS's via the `compiled` command. This actually simplifies the code, suggesting separating the `java` and `--build` type arguments. It has no impact on Windows due to the `if()` statement so this can be safely merged.

Step towards closing #5 but raises a wider issue: #10