### PR TITLE
add numItineraries to the API query

### DIFF
--- a/R/otp-plan.R
+++ b/R/otp-plan.R
@@ -391,7 +391,8 @@ otp_plan_internal <- function(otpcon = NA,
       walkReluctance = walkReluctance,
       arriveBy = arriveBy,
       transferPenalty = transferPenalty,
-      minTransferTime = minTransferTime
+      minTransferTime = minTransferTime,
+      numItineraries = numItineraries
     )
   )
 


### PR DESCRIPTION
`otp_plan_internal()` doesn't pass numItineraries to the API query. This pull request fixes that.