### PR TITLE
creates dockerfile to run {opentripplanner} from docker

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^lucene/
 ^\.github$
 otp_parallel_log.txt
+^Dockerfile$

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rocker/geospatial:latest
+
+RUN install2.r --error --deps TRUE opentripplanner
+
+RUN apt-get update && apt-get install openjdk-8-jdk -y
+
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java


### PR DESCRIPTION
Hello @mem48 @Robinlovelace. Following up from that little email exchange we had, I created a Dockerfile to run `{opentripplaner}` from docker, which hopefully will save us some trouble regarding the whole changing Java versions thing. I thought that you'd might enjoy it, so I'm creating this PR.

The image:

- Builds on top of [`rocker/geospatial:latest` ](https://github.com/rocker-org/rocker#versioned-stack-builds-on-r-ver);
- Installs the stable `{opentripplanner}` version, and its dependencies, from CRAN;
- Installs `openjdk-8` and sets it as default `java`.

To build an image from the Dockerfile (must be within `opentripplanner` repo): 

`docker build -t otp_pkg_image .`

Then run it:

`docker run -e PASSWORD=<yourpass> -p 8787:8787 otp_pkg_image`

Then, to use it, connect to `localhost:8787` from a web browser (substitute `localhost` to docker's ip if launching it from Windows or MacOS). You'll be prompted to a RStudio cloud login screen. Log in using username `rstudio` and password `<yourpass>`. Then enjoy using `{opentripplanner}`. I have successfully managed to run the example in your [introductory vignette](https://docs.ropensci.org/opentripplanner/articles/opentripplanner.html) with it, but let me know if you face any problems.

I hope this PR makes the whole `{opentripplanner}` experience as smooth as possible :)

Cheers!