### PR TITLE
add SUBWAY and TRAM as separate usable options, as RAIL does not work for "subway-only + walking" routing

### DIFF
--- a/R/otp-plan.R
+++ b/R/otp-plan.R
@@ -138,7 +138,7 @@ otp_plan <- function(otpcon = NA,
   checkmate::assert_subset(mode,
                            choices = c(
                              "TRANSIT", "WALK", "BICYCLE",
-                             "CAR", "BUS", "RAIL"
+                             "CAR", "BUS", "RAIL", "SUBWAY", "TRAM"
                            ),
                            empty.ok = FALSE
   )


### PR DESCRIPTION
add SUBWAY and TRAM as separate usable options, as RAIL does not work for "subway-only + walking" routing