### PR TITLE
Avoid using equality checks / %in% on class()

### DIFF
--- a/R/otp-connect.R
+++ b/R/otp-connect.R
@@ -106,8 +106,8 @@ otp_connect <- function(hostname = "localhost",
 #' @noRd
 #'
 make_url <- function(x, type = "routers") {
-  if(!"otpconnect" %in% class(x)){
-    stop("Object is not of class otpconnect, class is ", class(x))
+  if (!is_otpconnect(x)) {
+    stop("Object is not of class otpconnect, class is ", toString(class(x)))
   }
 
   if(type == "routers"){
@@ -167,8 +167,8 @@ make_url <- function(x, type = "routers") {
 #' @noRd
 #'
 check_router <- function(x) {
-  if(!"otpconnect" %in% class(x)){
-    stop("Object is not of class otpconnect, class is ", class(x))
+  if (!is_otpconnect(x)) {
+    stop("Object is not of class otpconnect, class is ", toString(class(x)))
   }
   check <- try(curl::curl_fetch_memory(make_url(x)), silent = TRUE)
   if (inherits(check, "try-error")) {
@@ -184,8 +184,8 @@ check_router <- function(x) {
 #' @noRd
 #'
 check_routers <- function(otpcon) {
-  if(!"otpconnect" %in% class(otpcon)){
-    stop("Object is not of class otpconnect, class is ", class(otpcon))
+  if (!is_otpconnect(otpcon)) {
+    stop("Object is not of class otpconnect, class is ", toString(class(otpcon)))
   }
 
   if (is.null(otpcon$url)) {

--- a/R/otp-plan.R
+++ b/R/otp-plan.R
@@ -424,12 +424,12 @@ otp_parse_missing <- function(x){
 
 otp_clean_input <- function(imp, imp_name) {
   # For single point inputs
-  if (all(class(imp) == "numeric")) {
+  if (!is.matrix(imp) && is.double(imp)) {
     checkmate::assert_numeric(imp, len = 2)
     imp <- matrix(imp, nrow = 1, byrow = TRUE)
   }
   # For SF inputs
-  if ("sf" %in% class(imp)) {
+  if (inherits(imp, "sf")) {
     if (all(sf::st_geometry_type(imp) == "POINT")) {
       imp <- sf::st_coordinates(imp)
       imp[] <- imp[, c(1, 2)]
@@ -440,7 +440,7 @@ otp_clean_input <- function(imp, imp_name) {
 
   # For matrix inputs
   # if (all(class(imp) == "matrix")) { # to pass CRAN checks
-  if ("matrix" %in% class(imp)) {
+  if (is.matrix(imp)) {
     checkmate::assert_matrix(imp,
                              any.missing = FALSE,
                              min.rows = 1,

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -345,7 +345,7 @@ otp_setup <- function(otp = NULL,
         check = TRUE
       ), silent = TRUE)
 
-      if ("otpconnect" %in% class(otpcon)) {
+      if (is_otpconnect(otpcon)) {
         message(paste0(
           Sys.time(),
           " OTP is ready to use Go to localhost:",

--- a/R/otp-surface.R
+++ b/R/otp-surface.R
@@ -266,7 +266,7 @@ otp_pointset <- function(points = NULL,
                         name = NULL,
                         dir = NULL) {
 
-  if(!"sf" %in% class(points)){
+  if (!inherits(point, "sf")) {
     stop("points is not an sf object")
   }
 

--- a/R/utility-functions.R
+++ b/R/utility-functions.R
@@ -122,3 +122,9 @@ split_alternating <- function(x){
                     check.names = FALSE,
                     check.rows = FALSE))
 }
+
+#' Check for 'otpconnect' class
+#' @param x An object.
+#' @family internal
+#' @noRd
+is_otpconnect <- function(x) inherits(x, "otpconnect")

--- a/tests/testthat/test_01_internal_funcs.R
+++ b/tests/testthat/test_01_internal_funcs.R
@@ -52,7 +52,7 @@ test_that("test otp_json2sf", {
 
 
   r1 <- otp_json2sf(itineraries = r1, fp = "", tp = "", get_elevation = FALSE)
-  expect_true("data.frame" %in% class(r1))
+  expect_s3_class(r1, "data.frame")
   expect_true(nrow(r1) == 1)
 
 
@@ -63,7 +63,7 @@ test_that("test otp_json2sf", {
 
 
   r2 <- otp_json2sf(r2, fp = "", tp = "", get_geometry = FALSE)
-  expect_true("data.frame" %in% class(r2))
+  expect_s3_class(r2, "data.frame")
   expect_true(nrow(r2) == 1)
 
 
@@ -73,7 +73,7 @@ test_that("test otp_json2sf", {
 
 
   r4 <- otp_json2sf(itineraries = r4, fp = "", tp = "")
-  expect_true("data.frame" %in% class(r4))
+  expect_s3_class(r4, "data.frame")
   expect_true(nrow(r4) == 9)
 })
 
@@ -88,10 +88,10 @@ test_that("get elevations", {
     get_geometry = TRUE,
     full_elevation = TRUE
   )
-  expect_true("data.frame" %in% class(r3))
+  expect_s3_class(r3, "data.frame")
   expect_true(nrow(r3) == 1)
   expect_true("leg_elevation" %in% names(r3))
-  expect_true(class(r3$leg_elevation) == "list")
+  expect_true(is.list(r3$leg_elevation))
 })
 
 
@@ -159,7 +159,7 @@ test_that("test polyline2linestring", {
 
 test_that("test otp_check_java", {
   suppressWarnings(r1 <- otp_check_java())
-  expect_true(class(r1) == "logical")
+  expect_type(r1, "logical")
 })
 
 

--- a/tests/testthat/test_02_without_OTP.R
+++ b/tests/testthat/test_02_without_OTP.R
@@ -287,10 +287,10 @@ context("test routing options")
 test_that("otp_routing_options creation", {
   skip_on_cran()
   routingOptions <- otp_routing_options()
-  expect_true(class(routingOptions) == "list")
+  expect_true(is.list(routingOptions))
   routingOptions$walkSpeed <- 999
   routingOptions <- otp_validate_routing_options(routingOptions)
-  expect_true(class(routingOptions) == "list")
+  expect_true(is.list(routingOptions))
   expect_true(length(routingOptions) == 1)
 })
 


### PR DESCRIPTION
Just started with the package so thought I'd try and contribute back some code quality fixes as a token of thanks.

Found with `lintr::class_equals_linter()`. Some of the changes (noted in a comment) require more context than I have to execute completely correctly, so feedback welcome on things that need more fine-tuning.

There are many other changes found with `lintr::lint_package(linters = lintr::all_linters())`; many of them are stylistic but others have implications for correctness, too.