### PR TITLE
update messaging on OTP isochrone support from 2.2 to 2.5

### DIFF
--- a/R/otp-isochrone-batch.R
+++ b/R/otp-isochrone-batch.R
@@ -53,17 +53,22 @@ otp_isochrone <- function(otpcon = NA,
                           timezone = otpcon$timezone) {
   # Check for OTP2
   if (!is.null(otpcon$otp_version)) {
-    if (otpcon$otp_version >= 2.0 & otpcon$otp_version <= 2.1) {
-      stop("Isochrones are not supported by OTP v2.0-2.1. Consider using v1.5 or v2.2+.")
-    } else if (otpcon$otp_version >= 2.2) {
-      message("OTP v2.2+ experimentaly supports isochrones, see https://docs.opentripplanner.org/en/v2.4.0/sandbox/TravelTime/")
+    if (otpcon$otp_version >= 2.2 & otpcon$otp_version <= 2.5) {
+      message(
+        "OTP v2.2 to v2.5 support isochrones experimentally, see https://docs.opentripplanner.org/en/v2.5.0/sandbox/TravelTime/ . Starting with OTP 2.6 the support for isochrones has been removed."
+      )
+    } else {
+      stop(sprintf(
+        "Isochrones are not supported by OTP v%s. Please use OTP v2.2 to v2.5.",
+        otpcon$otp_version
+      ))
     }
   }
 
   # Warn about walking isochrones not being supported by OTP v2
   if (otpcon$otp_version >= 2.0) {
     if (length(mode) == 1 && mode == "WALK") {
-      warning("Walking-only isochrones are not supported by OTP v2. You can only use \"WALK,TRANSIT\". When set to \"WALK\" OTPv2 defaults to  \"WALK,TRANSIT\". See https://docs.opentripplanner.org/en/v2.4.0/sandbox/TravelTime/")
+      warning("Walking-only isochrones are not supported by OTP v2. You can only use \"WALK,TRANSIT\". When set to \"WALK\" OTPv2 defaults to  \"WALK,TRANSIT\". See https://docs.opentripplanner.org/en/v2.5.0/sandbox/TravelTime/")
     }
   }
 

--- a/R/otp-isochrone-batch.R
+++ b/R/otp-isochrone-batch.R
@@ -52,7 +52,7 @@ otp_isochrone <- function(otpcon = NA,
                           ncores = max(round(parallel::detectCores() * 1.25) - 1,1),
                           timezone = otpcon$timezone) {
   # Check for OTP2
-  if (!is.null(otpcon$otp_version)) {
+  if (!is.null(otpcon$otp_version) && otpcon$otp_version >= 2.0) {
     if (otpcon$otp_version >= 2.2 & otpcon$otp_version <= 2.5) {
       message(
         "OTP v2.2 to v2.5 support isochrones experimentally, see https://docs.opentripplanner.org/en/v2.5.0/sandbox/TravelTime/ . Starting with OTP 2.6 the support for isochrones has been removed."

--- a/R/otp-setup.R
+++ b/R/otp-setup.R
@@ -577,24 +577,27 @@ otp_check_java <- function(otp_version = 1.5) {
     }
 
     if (otp_version >= 2.2) {
-      if (java_version >= 1.8 & java_version < 1.9) {
-        warning("You have OTP 2.2+ but the version of Java for OTP 1.x")
-        return(FALSE)
+      if (otp_version < 2.5) {
+        # OTP 2.2 to 2.4 require Java 17 or later.
+        if (java_version < 17) {
+          warning("OTP 2.2 to 2.4 require Java version 17 or later; you have version ", java_version)
+          return(FALSE)
+        } else {
+          message("You have the correct version of Java for OTP ", otp_version, " (requires Java 17 or later)")
+          return(TRUE)
+        }
+      } else {
+        # OTP 2.5 or later require Java 21 or later.
+        if (java_version < 21) {
+          warning("OTP 2.5+ require Java version 21 or later; you have version ", java_version)
+          return(FALSE)
+        } else {
+          message("You have the correct version of Java for OTP ", otp_version, " (requires Java 21 or later)")
+          return(TRUE)
+        }
       }
-
-      if (java_version == 11) {
-        warning("You have OTP 2.2+ but the version of Java for OTP 2.0 or 2.1")
-        return(FALSE)
-      }
-
-      if (java_version == 17) {
-        message("You have the correct version of Java for OTP 2.2+")
-        return(TRUE)
-      }
-
-      warning("OTP 2.2+ requires Java version 17 you have version ", java_version)
-      return(FALSE)
     }
+    
 
     warning("OTP requires Java version 1.8 you have version ", java_version)
     return(FALSE)


### PR DESCRIPTION
OTP releases that do support Isochrones:

https://docs.opentripplanner.org/en/v2.2.0/sandbox/TravelTime/
https://docs.opentripplanner.org/en/v2.3.0/sandbox/TravelTime/
https://docs.opentripplanner.org/en/v2.4.0/sandbox/TravelTime/
https://docs.opentripplanner.org/en/v2.5.0/sandbox/TravelTime/

Comment stating that Isochrone support is removed from OTP 2.x:
https://github.com/opentripplanner/OpenTripPlanner/issues/4880#issuecomment-2160921709

Basically, the isochrones are gone starting with OTP 2.6.

So this PR will at least allow the users to use OTP 2.2-2.5, but long term there is no point in supporting the isochrones. Sad.