### PR TITLE
Java versions for OTP and install instructions

### DIFF
--- a/vignettes/OTPv2.Rmd
+++ b/vignettes/OTPv2.Rmd
@@ -34,7 +34,8 @@ Different versions of OpenTripPlanner require different version of Java
 
 * OTP 1.x  - Java 8
 * OTP 2.0 & 2.1  - Java 11
-* OTP 2.2 - Java 17
+* OTP 2.2–2.4  - Java 17
+* OTP 2.5–2.6+  - Java 21
 
 It is possible to install multiple version of Java on the same computer:
 
@@ -43,12 +44,35 @@ It is possible to install multiple version of Java on the same computer:
 * [Java 8](https://www.java.com/en/download/)
 * [Java 11](https://www.oracle.com/uk/java/technologies/javase/jdk11-archive-downloads.html)
 * [Java 17](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
+* [Java 21](https://www.oracle.com/java/technologies/javase/jdk21-archive-downloads.html)
+
 
 If you have multiple version of Java installed you will also need to change the PATH variable to point to the correct version of Java. You can check your current default version of Java in the terminal using
 
 ```{bash, eval = FALSE}
 java -version
 ```
+
+### Quick Java installation
+
+You can also install Java programmatically from R using [`{rJavaEnv}`](https://cran.r-project.org/package=rJavaEnv) package.
+
+For example, install and use Java 8 for use with OTP 1.5 in the current R session:
+
+```{r, eval = FALSE}
+install.packages("rJavaEnv")
+library(rJavaEnv)
+use_java(8) 
+```
+
+Alternatively, install permanently for the current project directory Java 21 for use with OTP 2.5+:
+
+```{r, eval = FALSE}
+install.packages("rJavaEnv")
+library(rJavaEnv)
+java_quick_install(21)
+```
+
 
 
 ## Checking your Java version
@@ -83,6 +107,3 @@ log2 <- otp_setup(otp = path_otp, dir = path_data)
 otpcon <- otp_connect(timezone = "Europe/London")
 ```
 We can download the demo data and build a graph in the usual way.
-
-
-

--- a/vignettes/opentripplanner.Rmd
+++ b/vignettes/opentripplanner.Rmd
@@ -38,6 +38,20 @@ remotes::install_github("ropensci/opentripplanner") # Install Package
 library(opentripplanner)                            # Load Package
 ```
 
+Check if you have the correct Java version installed:
+
+```{r check_java, eval=FALSE}
+otp_check_java()
+```
+
+If you do not have the correct Java version, you can install it and immidiately use in the current R session with:
+
+```{r install_java, eval=FALSE}
+install.packages("rJavaEnv")
+library(rJavaEnv)
+use_java(8)
+```
+
 ## Downloading OTP and the demonstration data
 
 We will build an example graph for the Isle of Wight using some example data provided for the package. A graph is what OTP uses to find routes, and must be built out of the raw data provided. Please note the demo data has been modified for teaching purposes and should not be used for analysis.

--- a/vignettes/prerequisites.Rmd
+++ b/vignettes/prerequisites.Rmd
@@ -92,8 +92,9 @@ The OpenTripPlanner for R package requires:
 Different versions of OTP require different version of Java
 
 * OTP v1.5 - Java 8 - **Recommended for beginners**
-* OTP v2.0 & v2.1 - Java 11
-* OTP v2.2 - Java 17
+* OTP 2.0 & 2.1  - Java 11
+* OTP 2.2–2.4  - Java 17
+* OTP 2.5–2.6+  - Java 21
 
 Use of OTP v1.5 is the default for this package and recommended for beginners and it is stable and full featured. Future updates of the package will add more support for OTP v2.2+.
 
@@ -112,6 +113,27 @@ For Debian based Linux including Ubuntu and Linux Mint, the following commands i
 ```{eval = FALSE}
 sudo apt install openjdk-8-jdk
 ```
+
+##### Quick Java installation
+
+You can also install Java programmatically from R using [`{rJavaEnv}`](https://cran.r-project.org/package=rJavaEnv) package.
+
+For example, install and use Java 8 for use with OTP 1.5 in the current R session:
+
+```{r, eval = FALSE}
+install.packages("rJavaEnv")
+library(rJavaEnv)
+use_java(8) 
+```
+
+Alternatively, install permanently for the current project directory Java 21 for use with OTP 2.5+:
+
+```{r, eval = FALSE}
+install.packages("rJavaEnv")
+library(rJavaEnv)
+java_quick_install(21)
+```
+
 
 ## Next Steps
 


### PR DESCRIPTION
Following up on #120 , I updated the vignettes to include up to date OTP dependency on different Java versions. I also added instructions on how to easily setup Java in one line of code from within R using https://github.com/e-kotov/rJavaEnv . I believe these instructions can help the newcomers.